### PR TITLE
Fixes a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Hexroll is an OSR sandbox generator designed to provide a backdrop for table-top
 
 | Entity                               | File                    |
 | ------------------------------------ | ----------------------- |
-| AbberationHD1 | monster_groups.yaml|
-| AbberationHD3 | monster_groups.yaml|
-| AbberationHD5 | monster_groups.yaml|
-| AbberationHD6 | monster_groups.yaml|
-| AbberationHD8 | monster_groups.yaml|
-| AbberationHD9 | monster_groups.yaml|
-| AbberationHD13 | monster_groups.yaml|
-| AbberationHD15 | monster_groups.yaml|
+| AberrationHD1 | monster_groups.yaml|
+| AberrationHD3 | monster_groups.yaml|
+| AberrationHD5 | monster_groups.yaml|
+| AberrationHD6 | monster_groups.yaml|
+| AberrationHD8 | monster_groups.yaml|
+| AberrationHD9 | monster_groups.yaml|
+| AberrationHD13 | monster_groups.yaml|
+| AberrationHD15 | monster_groups.yaml|
 | Acolyte | monsters.yaml|
 | AdventurersGuild | shops.yaml|
 | Advert | quests.yaml|
@@ -187,10 +187,10 @@ Hexroll is an OSR sandbox generator designed to provide a backdrop for table-top
 | DungeonDoorState | dungeon_doors.yaml|
 | DungeonDoorStuck | dungeon_doors.yaml|
 | DungeonDoor | dungeon_doors.yaml|
-| DungeonEncounterAbberationsTier1 | dungeon_encounters.yaml|
-| DungeonEncounterAbberationsTier2 | dungeon_encounters.yaml|
-| DungeonEncounterAbberationsTier3 | dungeon_encounters.yaml|
-| DungeonEncounterAbberations | dungeon_encounters.yaml|
+| DungeonEncounterAberrationsTier1 | dungeon_encounters.yaml|
+| DungeonEncounterAberrationsTier2 | dungeon_encounters.yaml|
+| DungeonEncounterAberrationsTier3 | dungeon_encounters.yaml|
+| DungeonEncounterAberrations | dungeon_encounters.yaml|
 | DungeonEncounterCultistsClasses | dungeon_encounters.yaml|
 | DungeonEncounterCultists | dungeon_encounters.yaml|
 | DungeonEncounterHumanoidsTier1 | dungeon_encounters.yaml|
@@ -549,9 +549,9 @@ Hexroll is an OSR sandbox generator designed to provide a backdrop for table-top
 | MonsterHD13 | monster_groups.yaml|
 | MonsterHD15 | monster_groups.yaml|
 | MonsterHD20 | monster_groups.yaml|
-| MonstersAbberationTier1 | dungeon_encounters.yaml|
-| MonstersAbberationTier2 | dungeon_encounters.yaml|
-| MonstersAbberationTier3 | dungeon_encounters.yaml|
+| MonstersAberrationTier1 | dungeon_encounters.yaml|
+| MonstersAberrationTier2 | dungeon_encounters.yaml|
+| MonstersAberrationTier3 | dungeon_encounters.yaml|
 | MonstersHumanoidTier1 | dungeon_encounters.yaml|
 | MonstersMagicalTier2 | dungeon_encounters.yaml|
 | MonstersMagicalTier3 | dungeon_encounters.yaml|

--- a/dungeon.yaml
+++ b/dungeon.yaml
@@ -343,7 +343,7 @@ DungeonDebris:
     - a spotted mushroom
     - a collection of offerings, long ago forgotten
     - several iron bars, each about a foot in length
-    - a boquet of flowers
+    - a bouquet of flowers
     - a muddy puddle
     - knitting needles and yarn
     - a pile of papers

--- a/dungeon_area_types.yaml
+++ b/dungeon_area_types.yaml
@@ -35,7 +35,7 @@ RoomTypeShrine:
     - Dense spiderwebs cover the corners of the room
     - Countless creepy crawlies all over rush back into the darkness
     - Large symbols and letters were painted all over the place
-    - Countless humanoid skulls “decorate” the boundries here
+    - Countless humanoid skulls “decorate” the boundaries here
     - A large pentagram was painted here
     - A small wooden altar is located at the center of this room
 
@@ -108,7 +108,7 @@ RoomTypeCeremonial:
     - Dense spiderwebs cover the corners of the room
     - Countless creepy crawlies all over rush back into the darkness
     - Large symbols and letters were painted all over the place
-    - Countless humanoid skulls “decorate” the boundries here
+    - Countless humanoid skulls “decorate” the boundaries here
     - A large pentagram was painted here
     - A small wooden altar is located at the center of this room
 

--- a/dungeon_encounters.yaml
+++ b/dungeon_encounters.yaml
@@ -41,12 +41,12 @@ MonstersOozeTier3:
     - OozeHD10
 
 
-MonstersAbberationTier1:
+MonstersAberrationTier1:
   $subclass:
-    - AbberationHD1
+    - AberrationHD1
 
 
-MonstersAbberationTier2:
+MonstersAberrationTier2:
   $subclass:
     - AberrationHD3
     - AberrationHD5
@@ -180,7 +180,7 @@ DungeonEncounterOozesTier3:
 
 
 
-DungeonEncounterAbberations:
+DungeonEncounterAberrations:
   $extends: DungeonEncounter
   Foreshadow: !jinja >
     A successful listening roll could detect the __sounds__
@@ -200,22 +200,22 @@ DungeonEncounterAbberations:
 
 
 
-DungeonEncounterAbberationsTier1:
-  $extends: DungeonEncounterAbberations
+DungeonEncounterAberrationsTier1:
+  $extends: DungeonEncounterAberrations
   Monster:
-    $roll: MonstersAbberationTier1
+    $roll: MonstersAberrationTier1
 
 
-DungeonEncounterAbberationsTier2:
-  $extends: DungeonEncounterAbberations
+DungeonEncounterAberrationsTier2:
+  $extends: DungeonEncounterAberrations
   Monster:
-    $roll: MonstersAbberationTier2
+    $roll: MonstersAberrationTier2
 
 
-DungeonEncounterAbberationsTier3:
-  $extends: DungeonEncounterAbberations
+DungeonEncounterAberrationsTier3:
+  $extends: DungeonEncounterAberrations
   Monster:
-    $roll: MonstersAbberationTier3
+    $roll: MonstersAberrationTier3
   Rumor:
     $roll:
       $class: Rumor

--- a/dungeon_encounters.yaml
+++ b/dungeon_encounters.yaml
@@ -417,7 +417,7 @@ DungeonEncounterMimic:
     - The ground under your feet feels a bit sticky
     - Your boots and feet feel sticky as you step forward
     - There is an unfamiliar stench in the air
-    - There is a very unpleasent smell around here
+    - There is a very unpleasant smell around here
 
 
 DungeonEncounterCaveSpecific:

--- a/dungeon_encounters.yaml
+++ b/dungeon_encounters.yaml
@@ -48,17 +48,17 @@ MonstersAbberationTier1:
 
 MonstersAbberationTier2:
   $subclass:
-    - AbberationHD3
-    - AbberationHD5
-    - AbberationHD6
+    - AberrationHD3
+    - AberrationHD5
+    - AberrationHD6
 
 
-MonstersAbberationTier3:
+MonstersAberrationTier3:
   $subclass:
-    - AbberationHD6
-    - AbberationHD8
-    - AbberationHD9
-    - AbberationHD13
+    - AberrationHD6
+    - AberrationHD8
+    - AberrationHD9
+    - AberrationHD13
 
 
 MonstersDragonsTier3:

--- a/dungeon_types.yaml
+++ b/dungeon_types.yaml
@@ -3,7 +3,7 @@ CaveEncounterTier1:
     - DungeonEncounterHumanoidsTier1^2
     - DungeonEncounterVerminsTier1
     - DungeonEncounterOozesTier1
-    - DungeonEncounterAbberationsTier1
+    - DungeonEncounterAbberationTier1
     - DungeonEncounterCaveSpecificTier1
 
 
@@ -12,7 +12,7 @@ CaveEncounterTier2:
     - DungeonEncounterHumanoidsTier1
     - DungeonEncounterVerminsTier2
     - DungeonEncounterOozesTier2
-    - DungeonEncounterAbberationsTier2
+    - DungeonEncounterAbberationTier2
     - DungeonEncounterCaveSpecificTier2
 
 
@@ -20,7 +20,7 @@ CaveEncounterTier3:
   $subclass:
     - DungeonEncounterVerminsTier3
     - DungeonEncounterOozesTier3
-    - DungeonEncounterAbberationsTier3
+    - DungeonEncounterAbberationTier3
     - DungeonEncounterDragonsTier3
 
 

--- a/dungeon_types.yaml
+++ b/dungeon_types.yaml
@@ -3,7 +3,7 @@ CaveEncounterTier1:
     - DungeonEncounterHumanoidsTier1^2
     - DungeonEncounterVerminsTier1
     - DungeonEncounterOozesTier1
-    - DungeonEncounterAbberationTier1
+    - DungeonEncounterAberrationTier1
     - DungeonEncounterCaveSpecificTier1
 
 
@@ -12,7 +12,7 @@ CaveEncounterTier2:
     - DungeonEncounterHumanoidsTier1
     - DungeonEncounterVerminsTier2
     - DungeonEncounterOozesTier2
-    - DungeonEncounterAbberationTier2
+    - DungeonEncounterAberrationTier2
     - DungeonEncounterCaveSpecificTier2
 
 
@@ -20,7 +20,7 @@ CaveEncounterTier3:
   $subclass:
     - DungeonEncounterVerminsTier3
     - DungeonEncounterOozesTier3
-    - DungeonEncounterAbberationTier3
+    - DungeonEncounterAberrationTier3
     - DungeonEncounterDragonsTier3
 
 
@@ -166,13 +166,13 @@ TempleEncounterTier1:
 TempleEncounterTier2:
   $subclass:
     - DungeonEncounterMagicalTier2
-    - DungeonEncounterAbberationsTier2
+    - DungeonEncounterAberrationsTier2
 
 
 TempleEncounterTier3:
   $subclass: !weighted
     - DungeonEncounterMagicalTier3^4
-    - DungeonEncounterAbberationsTier3^4
+    - DungeonEncounterAberrationsTier3^4
     - DungeonEncounterMimic
 
 

--- a/map_features.yaml
+++ b/map_features.yaml
@@ -203,7 +203,7 @@ Encounter:
                 ---
 
                 {%if not Monster.TreasureType.Empty%}
-                * __Lair__ hoard (__1-in-6__ base chance of finding if an encouter occured):
+                * __Lair__ hoard (__1-in-6__ base chance of finding if an encounter occurred):
                 {{Monster.TreasureType.Details}}
                 {%endif%}
 

--- a/monster_groups.yaml
+++ b/monster_groups.yaml
@@ -425,19 +425,19 @@ DynoHD20:
     - TyrannosaurusRex
 
 
-AbberationHD1:
+AberrationHD1:
   $subclass:
     - Stirge
 
 
-AbberationHD3:
+AberrationHD3:
   $subclass:
     - Hellhound
    #- Shrieker
     - Harpy
 
 
-AbberationHD5:
+AberrationHD5:
   $subclass:
     - Hydra
     - OwlBear
@@ -446,28 +446,28 @@ AbberationHD5:
     - Cockatrice
 
 
-AbberationHD6:
+AberrationHD6:
   $subclass:
     - Minotaur
     - WarpBeast
 
 
-AbberationHD8:
+AberrationHD8:
   $subclass:
     - Gorgon
 
 
-AbberationHD9:
+AberrationHD9:
   $subclass:
     - DevilSwine
 
 
-AbberationHD13:
+AberrationHD13:
   $subclass:
     - Cyclops
 
 
-AbberationHD15:
+AberrationHD15:
   $subclass:
     - PurpleWorm
 

--- a/realm.yaml
+++ b/realm.yaml
@@ -99,7 +99,7 @@ Realm:
     - !jinja >
       {{Title}} is in blissful equilibrium. {{Ruler.Title | title}} {{Ruler.NPC.Name.First}}'s
       and {{Ruler.NPC.Gender.Pronoun2}} his loyal forces keep any evil at bay and away.
-      But an greater, more sinister darkenss is approaching from far far away.
+      But an greater, more sinister darkness is approaching from far far away.
 
     - !jinja >
       {{Ruler.Title | title}} {{Ruler.NPC.Name.First}} is a beloved ruler,

--- a/settlement.yaml
+++ b/settlement.yaml
@@ -373,9 +373,9 @@ City:
 
 TavernDish:
   Description: !jinja >
-    {{Type}} {{Kind}} __{{MainIngrediant}}__,
-    {{Style}} __{{SecondIngrediant}}__ and {{Addition}}
-    __{{ThirdIngrediant}}__ for
+    {{Type}} {{Kind}} __{{MainIngredient}}__,
+    {{Style}} __{{SecondIngredient}}__ and {{Addition}}
+    __{{ThirdIngredient}}__ for
     __{{(Price*(DistrictContext.CostFactor if DistrictContext is defined else 1.0)) | currency}}__
 
   Type:
@@ -389,7 +389,7 @@ TavernDish:
     - slices of
     - chunks of
 
-  MainIngrediant:
+  MainIngredient:
     - meat
     - fish
     - shellfish
@@ -400,7 +400,7 @@ TavernDish:
     - marinated in
     - glazed with
 
-  SecondIngrediant:
+  SecondIngredient:
     - ale
     - red wine
     - white wine
@@ -410,7 +410,7 @@ TavernDish:
   Addition:
     - served with
   
-  ThirdIngrediant:
+  ThirdIngredient:
     - mashed potatoes
     - baked potatoes
     - cooked rice

--- a/shops.yaml
+++ b/shops.yaml
@@ -833,7 +833,7 @@ Tanner:
 
 Registry:
   $extends: Service
-  Title: Registery
+  Title: Registry
   Noun:
     - Registry
     - Registrars


### PR DESCRIPTION
There are a few different typo corrections here

First off, two typos that showed up on entity names were fixed (Abberation and Ingrediant), even though they don't show up to the user. Those should be reviewed with care, as I'm not sure I got all instances of them and that might lead to breaking the hex generation. Also, if those entity names are referenced in whatever is used to display the result of hexroll in the webpage, they should be changed there as well.

Then, there are a few typos that were found in text proper.

I hope I'm helping more than bothering.