### PR TITLE
Fixes Hex subclass property name

### DIFF
--- a/map.yaml
+++ b/map.yaml
@@ -210,7 +210,7 @@ Hex:
 
 
     {%endif%}
-  $sublcass:
+  $subclass:
     - MountainsHex
     - PlainsHex
     - ForestHex


### PR DESCRIPTION
I decided to open this in a separate PR as it probably will require a similar change in whatever uses this property to display hexes in the webpage at the least. So you can accept/reject this separately from the other suggestions.